### PR TITLE
v0.0.3 - Modified Continuous Integration to Run When Pull Request Merged

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,8 @@
 name: Continuous Integration
 
 on:
+  pull_request: 
+   types: merged
   push:
     branches:
       - main


### PR DESCRIPTION
Using pascalgn/automerge-action to automatically merge pull request does not directly trigger a push event.

Added pull_request: types merged as a workaround trigger